### PR TITLE
Windows compatibility

### DIFF
--- a/edgar/constants.py
+++ b/edgar/constants.py
@@ -1,8 +1,8 @@
-import os
+from urllib.parse import urljoin
 
 # Constants
-SEC_GOV_URL = 'https://www.sec.gov/Archives'
-FORM_INDEX_URL_TEMPLATE = os.path.join(SEC_GOV_URL, 'edgar/full-index/{}/QTR{}/form.idx')
+SEC_GOV_URL = 'https://www.sec.gov/Archives/'
+FORM_INDEX_URL_TEMPLATE = urljoin(SEC_GOV_URL, 'edgar/full-index/{}/QTR{}/form.idx')
 
 # Supported form types
 SUPPORTED_FORM_TYPES = ["10-K"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 beautifulsoup4
 requests
+ratelimit


### PR DESCRIPTION
There is an issue with using `os.path.join()` to form the URLs on Windows (uses `\` instead of '/').
I also added ratelimit to requirements.